### PR TITLE
Fixes weekend bug

### DIFF
--- a/js/analyzer.js
+++ b/js/analyzer.js
@@ -60,7 +60,7 @@ function Analyzer(data, classrooms) {
 	},
 
 	this.setupData = function(time) {
-		let weekday = weekdays[time.getDay() - 1],
+		let weekday = weekdays[time.getDay() - 1] || 'monday',
 				hours = time.getHours(),
 				minutes = time.getMinutes();
 
@@ -117,7 +117,7 @@ function Analyzer(data, classrooms) {
 	},
 
 	this.nextClasses = function(time) {
-		let weekday = weekdays[time.getDay() - 1],
+		let weekday = weekdays[time.getDay() - 1] || 'monday',
 				hours = time.getHours(),
 				minutes = time.getMinutes();
 


### PR DESCRIPTION
Atualmente tanto o site no **github-pages** quanto o projeto no branch **master** lança o seguinte erro:

```
Uncaught TypeError: Cannot read property '20' of undefined
    at Analyzer.setupData (analyzer.js:89)
    at load (main.js:27)
    at XMLHttpRequest.request.onreadystatechange (main.js:18)
```

Pelo que entendi esse erro só está sendo lançado **quando é final de semana (sábado ou domingo)**. 

Por exemplo: o **time.getDay()** no domingo é 0 e a seguinte linha dentro do Analyzer.setupData tenta acessar o índice -1 de weekdays:
`let weekday = weekdays[time.getDay() - 1] `

**weekdays:**
`const weekdays = [
	'monday',
	'tuesday',
	'wednesday',
	'thursday',
	'friday'
];`

Sugeri uma correção **paliativa**, ou seja, para evitar que o tem-lab fique sem uma resposta se tem ou não lab para o usuário qualquer que seja o dia da semana:

- Adicionar um valor default (no caso, 'monday') quando o `weekdays[time.getDay() - 1` tenta acessar um índice negativo e ficaria undefined.
`let weekday = weekdays[time.getDay() - 1] || 'monday'`

Considerações:
- Não tenho certeza se realmente é a melhor maneira, pois no sábado o próximo horário indicaria **07h30m - Tem Dinalva** na interface, porém no dia seguinte, no domingo às 7h30m, evidentemente, não haverá lab.
![1](https://user-images.githubusercontent.com/18057391/47262989-293c4500-d4cd-11e8-9b6d-1195d97f2400.PNG)
###### Imagem acima demonstra como seria o acesso no sábado, indicando que no dia seguinte às 7h30pm tem lab.